### PR TITLE
Fix parsing of ops parameter

### DIFF
--- a/lib/batch_api/processor.rb
+++ b/lib/batch_api/processor.rb
@@ -81,7 +81,7 @@ module BatchApi
           "Only #{BatchApi.config.limit} operations can be submitted at once, " +
           "#{ops.length} were provided"
       else
-        ops.map do |op|
+        ops.values.map do |op|
           self.class.operation_klass.new(op, @env, @app)
         end
       end


### PR DESCRIPTION
This fix was described by @kissrobber on this issue: https://github.com/arsduo/batch_api/issues/25

I applied the patch and it fixed these errors described by this issue for me as well. 
