### PR TITLE
Use to_json method instead of MultiJson.dump method

### DIFF
--- a/lib/batch_api/error_wrapper.rb
+++ b/lib/batch_api/error_wrapper.rb
@@ -27,7 +27,7 @@ module BatchApi
     #
     # Returns: an Array with the error body represented as JSON.
     def render
-      [status_code, RackMiddleware.content_type, [MultiJson.dump(body)]]
+      [status_code, RackMiddleware.content_type, [body.to_json]]
     end
 
     # Public: the status code to return for the given error.

--- a/lib/batch_api/rack_middleware.rb
+++ b/lib/batch_api/rack_middleware.rb
@@ -10,7 +10,7 @@ module BatchApi
         begin
           request = request_klass.new(env)
           result = BatchApi::Processor.new(request, @app).execute!
-          [200, self.class.content_type, [MultiJson.dump(result)]]
+          [200, self.class.content_type, [result.to_json]]
         rescue => err
           ErrorWrapper.new(err).render
         end


### PR DESCRIPTION
**Changelog:**
- Replace MultiJson.dump method with to_json method

**Error:**
- `NameError (uninitialized constant BatchApi::ErrorWrapper::MultiJson)`
